### PR TITLE
Update plugin installation

### DIFF
--- a/t/Renard/API/AnkiConnect/REST.t
+++ b/t/Renard/API/AnkiConnect/REST.t
@@ -41,7 +41,7 @@ fun install_ankiconnect( $base_dir ) {
 	my $addon_zip = Path::Tiny->tempfile( SUFFIX => ".zip" );
 	$addon_zip->spew_raw($response->{content});
 	my $zip = Archive::Zip->new( "$addon_zip" );
-	$zip->extractTree( "${ankiconnect_url_prefix}/plugin", "$addon_directory" );
+	$zip->extractTree( "${ankiconnect_url_prefix}/plugin", "@{[ $addon_directory->realpath ]}" );
 
 	$addon_directory->child('meta.json')->spew_utf8(qq|{"name": "AnkiConnect", "mod": @{[ time() ]}}|);
 }

--- a/t/Renard/API/AnkiConnect/REST.t
+++ b/t/Renard/API/AnkiConnect/REST.t
@@ -13,7 +13,7 @@ use File::HomeDir;
 use lib 't/lib';
 
 fun kill_anki() {
-	my $procs = killall('HUP', 'anki');
+	my $procs = killall('HUP', qr/\b[aA]nki\b/);
 	sleep 1 if( $procs );
 }
 

--- a/t/Renard/API/AnkiConnect/REST.t
+++ b/t/Renard/API/AnkiConnect/REST.t
@@ -12,8 +12,12 @@ use File::HomeDir;
 
 use lib 't/lib';
 
-my $procs = killall('HUP', 'anki');
-sleep 1 if( $procs );
+fun kill_anki() {
+	my $procs = killall('HUP', 'anki');
+	sleep 1 if( $procs );
+}
+
+kill_anki;
 
 my $unix_path = path('~/.local/share/Anki2');
 my $macos_path = path('~/Library/Application Support/Anki2');
@@ -107,6 +111,8 @@ subtest "Testing API creation" => fun() {
 		fail 'could not get response';
 	})->followed_by(sub {
 		$rest->guiExitAnki->get;
+		sleep 3;
+		kill_anki;
 	});
 
 	$loop->await_all($future, $anki_func_future);


### PR DESCRIPTION
The plugin was moved into the `plugin/` directory of the git repository,
so download the `.zip` file and extract it instead.

See <https://github.com/FooSoft/anki-connect/commit/bb62a1e93f8672fa6e07fad4ae897029b8405642>.
